### PR TITLE
Implement prune-resource, deployment stage

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 const remote = require('./lib/remote.js');
 const { validateDefinition, validateConfig } = require('./lib/validate.js');
-const { generateResources } = require('./lib/resource.js');
+const { generateResources, removeUnusedResources } = require('./lib/resource.js');
 const { generateAlarms } = require('./lib/alarm.js');
+const { deployStage } = require('./lib/deploy.js');
 const { setStore, purgeStore, wait } = require('./lib/util.js');
 const yaml = require('js-yaml');
 const fs = require('fs');
@@ -40,6 +41,8 @@ const esanuka = async (defs, options = {}, dryRun = false) => {
   await generateResources(config.restApiId, defs, resources);
   console.log('\n======================= ALARM GENERATION =========================');
   await generateAlarms(config.restApiId, defs);
+  console.log('\n=================== Prune unused resources =======================');
+  await removeUnusedResources(config.restApiId, defs.resources, resources);
   purgeStore();
 };
 
@@ -56,5 +59,6 @@ const factory = (files, binds) => {
 };
 
 module.exports = (defs, options) => esanuka(defs, options);
+module.exports.deploy = deployStage;
 module.exports.dryRun = (defs, options) => esanuka(defs, options, true);
 module.exports.factory = factory;

--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -1,0 +1,21 @@
+const { apigatway } = require('./aws.js');
+const { wait } = require('./util.js');
+const logger = require('./log.js')('deploy');
+
+const deployStage = async (restApiId, stageName, variables) => {
+  const date = new Date();
+  const input = {
+    restApiId,
+    stageName,
+    variables,
+    cacheClusterEnabled: false,
+    description: `[${process.env.CIRCLE_SHA1 || 'manual'}] deployed by esanuka at ${date.toLocaleString()}`
+  };
+  logger(`Deploy Resources to ${stageName} --------------------->`);
+  await wait();
+  await apigatway.createDeployment(input).promise();
+};
+
+module.exports = {
+  deployStage
+};

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -19,10 +19,11 @@ const generateBinaryTypes = async restApiId => {
   await wait();
 };
 
-const findOrCreateParentResourceId = async (restApiId, endpoint, remote) => {
+const findOrCreateResource = async (restApiId, endpoint, remote) => {
   // always exists '/' of root path
   const root = remote['/'];
   let parentId = root.id;
+  let resource = root;
   await endpoint.split('/').filter(p => p).reduce(async (prev, next) => {
     const p = await prev;
     const path = `${p === '/' ? '' : p}/${next}`;
@@ -34,14 +35,19 @@ const findOrCreateParentResourceId = async (restApiId, endpoint, remote) => {
       } else {
         const resp = await apigateway.createResouce(input);
         await wait();
+        resource = {
+          id: resp.Id,
+          resource: Object.assign({}, input)
+        }
         parentId = resp.id;
       }
     } else {
+      resource = remote[path];
       parentId = remote[path].id;
     }
     return path;
   }, '/');
-  return parentId;
+  return resource;
 };
 
 const generateResources = async (restApiId, definition, remote) => {
@@ -64,12 +70,13 @@ const generateResources = async (restApiId, definition, remote) => {
     // check remote resource already exists
     if (!remote.hasOwnProperty(path)) {
       // get or create resource
-      const id = await findOrCreateParentResourceId(restApiId, path, remote);
-      remote[path] = {
-        id,
-        resource: { restApiId },
-        methods: {}
-      };
+      const resource = await findOrCreateResource(restApiId, path, remote);
+      console.log(resource);
+      if (resource.hasOwnProperty('methods')) {
+        remote[path] = resource;
+      } else {
+        remote[path] = Object.assign(resource, { methods: {} });
+      }
     }
     const remoteResource = remote[path];
     console.log(`\n==================== process for path: ${path} =====================`);
@@ -78,6 +85,43 @@ const generateResources = async (restApiId, definition, remote) => {
   }));
 };
 
+const removeUnusedResources = async (restApiId, localResources, remoteResources) => {
+  const paths = Object.keys(remoteResources);
+  const finder = path => {
+    return localResources.find(resource => {
+      const r = resource.path === '/' ? '/' : resource.path.replace(/\/$/, '');
+      const p = path === '/' ? '/' : path.replace(/\/$/, '');
+      return r === p;
+    });
+  };
+  const haveChildResources = resource => {
+    const id = resource.id;
+    return paths.find(path => {
+      return remoteResources[path].resource.parentId === id;
+    });
+  };
+
+  await Promise.all(paths.map(async path => {
+    // Definition not found in local
+    if (finder(path)) {
+      return;
+    }
+    // But if resource has child resources, DO NOT remove
+    if (haveChildResources(remoteResources[path])) {
+      return;
+    }
+    if (isDryrun()) {
+      logger(`Remove resource: ${path}`);
+    } else {
+      await apigateway.deleteResource({
+        restApiId,
+        resourceId: remoteResources[path].id
+      }).promise();
+    }
+  }));
+};
+
 module.exports = {
-  generateResources
+  generateResources,
+  removeUnusedResources
 };


### PR DESCRIPTION
To keep consistency, we'd like to remove unused resource in remote APIGateway.
And, also implement `createDeployment` calling function.