### PR TITLE
Enable to skip function check

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const defaultConfig = {
   baseDomain: '',
   restApiId: '',
   deploymentStage: '',
-  verbose: false
+  verbose: false,
+  skipFunctionExistence: false
 };
 
 const esanuka = async (defs, options = {}, dryRun = false) => {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -52,8 +52,10 @@ const validateAuthorizers = async authorizers => {
       throw new Error(`Invalid authorizer on index ${key}: function field is required and must exist`);
     }
     // function validate
-    await lambda.getFunction({ FunctionName: authorizer.function }).promise();
-    await wait();
+    if (!getStore('skipFunctionExistence')) {
+      Vawait lambda.getFunction({ FunctionName: authorizer.function }).promise();
+      await wait();
+    }
   }));
 };
 


### PR DESCRIPTION
This PR adds `skipFunctionExsitence` option which enables to skip function actual existence on AWS.