### PR TITLE
Fix parameter typo

### DIFF
--- a/lib/authorizer.js
+++ b/lib/authorizer.js
@@ -31,7 +31,7 @@ const generateAuthorizers = async (restApiId, authorizers) => {
           authType: 'custom',
           authorizerResultTtlInSeconds: authorizer.ttl || 300,
           authorizerUri: `arn:aws:apigateway:${region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${region}:${accountId}:function:${authorizer.function}/invocations`,
-          identifySource: _getAuthorizerIdentifySource(authorizer)
+          identitySource: _getAuthorizerIdentifySource(authorizer)
         }).promise();
         await wait(1);
         prev[name] = created.id;

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,9 +82,9 @@ js-yaml@^3.13.1:
     esprima "^4.0.0"
 
 minimist@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-  integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 punycode@1.3.2:
   version "1.3.2"


### PR DESCRIPTION
This PR fixes parameter field typo:

```
identifySource -> identitySource
```