### PR TITLE
fix lambda integration

### DIFF
--- a/lib/method.js
+++ b/lib/method.js
@@ -157,7 +157,7 @@ const generateMethods = async (localResource, remoteResource, authorizers) => {
         }
         await addLambdaFunctionPermission(resourceBase, localResource.path, arn, localMethod.function);
         await generateLambdaIntegration(resourceBase, arn, integration);
-        break;
+        continue;
       case 'http':
         await generateHttpProxyIntegration(resourceBase, localMethod, integration);
         break;

--- a/lib/method.js
+++ b/lib/method.js
@@ -157,8 +157,7 @@ const generateMethods = async (localResource, remoteResource, authorizers) => {
         }
         await addLambdaFunctionPermission(resourceBase, localResource.path, arn, localMethod.function);
         await generateLambdaIntegration(resourceBase, arn, integration);
-        // Note that return after lambda integration, because lambda integration doesn't need any response integration.
-        return;
+        break;
       case 'http':
         await generateHttpProxyIntegration(resourceBase, localMethod, integration);
         break;


### PR DESCRIPTION
This PR fixes lambda integration.

After generate lambda integration, stop loop and exit generateMethods. To fix it, we should use `continue`, not return. 